### PR TITLE
Fixed extended events not showing up

### DIFF
--- a/application/models/accomplishment_model.php
+++ b/application/models/accomplishment_model.php
@@ -80,7 +80,7 @@ class Accomplishment_Model extends CI_Model
 			inner join
 				sites
 			using (site_id)
-			where (status != 'extended' and status != 'routine')
+			where (status != 'routine')
 		";
 
         $result = $this->db->query($sql);


### PR DESCRIPTION
Extended events are not showing up in the shift checker by staff. Fixed and they are now appearing on all shift dates.